### PR TITLE
Fix feed hover issue.

### DIFF
--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -229,6 +229,10 @@ address, blockquote, sup {
 	.feed-item .content h2 {
 		font-size: 14px!important;
 	}
+
+	.source .zg-bull {
+	    font-size: 14px;
+	}
 }
 
 .feed-item .entry-body, .feed-item .zm-item-answer {
@@ -813,7 +817,7 @@ a.shameimaru-link:hover {
 }
 
 html.no-touchevents .top-nav-dropdown a:hover {
-	background-color: #1376DA;	
+	background-color: #1376DA;
 }
 
 .top-nav-dropdown .zg-icon {
@@ -2067,7 +2071,7 @@ a.shameimaru-link:hover {
 }
 
 html.no-touchevents .top-nav-dropdown a:hover {
-	background-color: #1376DA;	
+	background-color: #1376DA;
 }
 
 .top-nav-dropdown .zg-icon {


### PR DESCRIPTION
在实验室开启新版首页后，信息流中的这个bullet字号没有对宽屏进行适配，导致鼠标浮动上去的时候feed文字会出现移动。

![image](https://cloud.githubusercontent.com/assets/7262715/11452685/04de3b88-962c-11e5-98a0-91c53057376c.png)

See issue #3 .
