### PR TITLE
Issue/font size issues

### DIFF
--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -2732,4 +2732,7 @@ html.no-touch .zm-item-tag:hover, html.no-touch .zm-item-tag-x:hover {
 .side-topic-item {
 	padding: 13px;
 }
+
+.zm-topic-cat-sub p {
+	height: 3.4em;
 }

--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -541,6 +541,7 @@ html.no-touch .zm-comment-box .load-more:hover {
 
 .zu-autohide {
 	transition: .1s;
+	font-size: 13px;
 }
 
 .feed-item.combine.first-combine .content, .feed-item.combine.first-combine .entry-body {

--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -2736,3 +2736,4 @@ html.no-touch .zm-item-tag:hover, html.no-touch .zm-item-tag-x:hover {
 .zm-topic-cat-sub p {
 	height: 3.4em;
 }
+}

--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -361,7 +361,6 @@ a.zu-main-feed-fresh-button:hover, a.zu-main-feed-fresh-button:active {
 }
 
 .feed-item+.feed-item, .feed-separator+.feed-item {
-	border-top: 1px solid #ddd;
 	padding: 18px 0 13px 0;
 }
 


### PR DESCRIPTION
为了不被作者打，我以后就不一个个开issue了，PR里面一起发吧……

这次fix三个地方：

**1. 新版首页信息流中的关注话题字号适配.**
![qq20151129-0 2x](https://cloud.githubusercontent.com/assets/7262715/11458549/2ef3baac-96fd-11e5-809d-5627c88d9970.png)

**2. 问题广场中问题简介高度适配.**
字号变大了然而框的大小没变，于是就显示不全了。因为行高是1.7em，所以我直接把高度改成3.4em了，不要用px了。
![qq20151130-0 2x](https://cloud.githubusercontent.com/assets/7262715/11458548/2ef18296-96fd-11e5-8852-5d9d9a20a732.png)

**3. 重复的border-top.**
信息流的feed-item有两个border-top，删去了重复的。其实我觉得之间的border去掉都可以……

另，Stylish里为什么要分成两套规则？
