### PR TITLE
fix vote up/down container margin top

### DIFF
--- a/flat_zhihu.CSS
+++ b/flat_zhihu.CSS
@@ -1646,6 +1646,10 @@ i.zm-profile-header-icon.sina {
 	line-height: 1.8em;
 	margin-bottom: 5px;
 }
+
+.zm-votebar.goog-scrollfloater-floating {
+	margin-top: 50px;
+}
 /*===========================================*/
 /*================== 右侧栏 ====================*/
 /*===========================================*/


### PR DESCRIPTION
It was blocked by the fixed top-header.

![edb5e021-43aa-4c85-be7e-73532819a1ab](https://cloud.githubusercontent.com/assets/1504159/24575592/5b43ec7a-165f-11e7-8a5f-81d3c1ada071.png)
> Before

<img width="881" alt="screen shot 2017-03-31 at 10 09 36 pm" src="https://cloud.githubusercontent.com/assets/1504159/24575596/6ad0d70c-165f-11e7-905c-db18a34218b5.png">
> After